### PR TITLE
Auto-generated sfz.lang file

### DIFF
--- a/sfz.lang
+++ b/sfz.lang
@@ -24,25 +24,20 @@
     <property name="block-comment-start">/*</property>
     <property name="block-comment-end">*/</property>
   </metadata>
-
   <styles>
-    <style id="header-region"  name="SFZ Region Header"     map-to="def:special-char"/>
-    <style id="headers-other"  name="SFZ Other Header"      map-to="def:type"/>
-    <style id="opcode"         name="SFZ Opcode"            map-to="def:keyword"/>
-    <style id="comment"        name="Comment"               map-to="def:comment"/>
-    <style id="decimal"        name="Decimal number"        map-to="def:decimal"/>
+    <style id="header-region" name="SFZ Region Header" map-to="def:special-char"/>
+    <style id="headers-other" name="SFZ Other Header" map-to="def:type"/>
+    <style id="opcode" name="SFZ Opcode" map-to="def:keyword"/>
+    <style id="comment" name="Comment" map-to="def:comment"/>
+    <style id="decimal" name="Decimal number" map-to="def:decimal"/>
     <style id="floating-point" name="Floating point number" map-to="def:floating-point"/>
-    <style id="included-file"  name="Included File"         map-to="def:string"/>
-    <style id="preprocessor"   name="Preprocessor"          map-to="def:preprocessor"/>
+    <style id="included-file" name="Included File" map-to="def:string"/>
+    <style id="preprocessor" name="Preprocessor" map-to="def:preprocessor"/>
   </styles>
-
   <definitions>
-
     <define-regex id="preproc-start">^\s*#\s*</define-regex>
-    
-    <define-regex id="N">[0-9]{1,3}</define-regex>    
+    <define-regex id="N">[0-9]{1,3}</define-regex>
     <define-regex id="eqN">[0-3]{1}</define-regex>
-
     <context id="decimal" style-ref="decimal">
       <match extended="true">
         (?&lt;![\w\.])
@@ -50,8 +45,6 @@
         (?![\w\.])
       </match>
     </context>
-
-    <!-- http://www.lysator.liu.se/c/ANSI-C-grammar-l.html -->
     <context id="float" style-ref="floating-point">
       <match extended="true">
         (?&lt;![\w\.])
@@ -61,7 +54,6 @@
         (?![\w\.])
       </match>
     </context>
-
     <context id="headers-others" style-ref="headers-other">
       <prefix>&lt;</prefix>
       <suffix>&gt;</suffix>
@@ -72,47 +64,46 @@
       <keyword>group</keyword>
       <keyword>master</keyword>
       <keyword>midi</keyword>
+      <keyword>region</keyword>
+      <keyword>sample</keyword>
     </context>
-
     <context id="headers-region" style-ref="header-region">
       <prefix>&lt;</prefix>
       <suffix>&gt;</suffix>
       <keyword>region</keyword>
       <keyword>=</keyword>
     </context>
-
     <context id="opcodes" style-ref="opcode">
       <keyword>amp_keycenter</keyword>
       <keyword>amp_keytrack</keyword>
       <keyword>amp_random</keyword>
-      <keyword>amp_velcurve_</keyword>
+      <keyword>amp_velcurve_\%{N}</keyword>
       <keyword>amp_veltrack</keyword>
+      <keyword>amp_veltrack_curvecc\%{N}</keyword>
+      <keyword>amp_veltrack_oncc\%{N}</keyword>
+      <keyword>amp_veltrack_random</keyword>
       <keyword>ampeg_attack</keyword>
-      <keyword>ampeg_attack_oncc\%{N}</keyword>
       <keyword>ampeg_attack_shape</keyword>
       <keyword>ampeg_attackcc\%{N}</keyword>
       <keyword>ampeg_decay</keyword>
-      <keyword>ampeg_decay_oncc\%{N}</keyword>
+      <keyword>ampeg_decay_curvecc\%{N}</keyword>
       <keyword>ampeg_decay_shape</keyword>
       <keyword>ampeg_decay_zero</keyword>
       <keyword>ampeg_decaycc\%{N}</keyword>
       <keyword>ampeg_delay</keyword>
-      <keyword>ampeg_delay_oncc\%{N}</keyword>
       <keyword>ampeg_delaycc\%{N}</keyword>
       <keyword>ampeg_dynamic</keyword>
       <keyword>ampeg_hold</keyword>
-      <keyword>ampeg_hold_oncc\%{N}</keyword>
+      <keyword>ampeg_hold_curvecc\%{N}</keyword>
       <keyword>ampeg_holdcc\%{N}</keyword>
       <keyword>ampeg_release</keyword>
-      <keyword>ampeg_release_oncc\%{N}</keyword>
       <keyword>ampeg_release_shape</keyword>
       <keyword>ampeg_release_zero</keyword>
       <keyword>ampeg_releasecc\%{N}</keyword>
       <keyword>ampeg_start</keyword>
-      <keyword>ampeg_start_oncc\%{N}</keyword>
       <keyword>ampeg_startcc\%{N}</keyword>
       <keyword>ampeg_sustain</keyword>
-      <keyword>ampeg_sustain_oncc\%{N}</keyword>
+      <keyword>ampeg_sustain_curvecc\%{N}</keyword>
       <keyword>ampeg_sustaincc\%{N}</keyword>
       <keyword>ampeg_vel2attack</keyword>
       <keyword>ampeg_vel2decay</keyword>
@@ -131,108 +122,199 @@
       <keyword>amplfo_freqchanaft</keyword>
       <keyword>amplfo_freqpolyaft</keyword>
       <keyword>amplitude</keyword>
-      <keyword>amplitude_cc\%{N}</keyword>
       <keyword>amplitude_curvecc\%{N}</keyword>
-      <keyword>amplitude_mod</keyword>
       <keyword>amplitude_oncc\%{N}</keyword>
       <keyword>amplitude_smoothcc\%{N}</keyword>
+      <keyword>apan_depth</keyword>
+      <keyword>apan_depth_oncc\%{N}</keyword>
+      <keyword>apan_dry</keyword>
+      <keyword>apan_dry_oncc\%{N}</keyword>
+      <keyword>apan_freq</keyword>
+      <keyword>apan_freq_oncc\%{N}</keyword>
+      <keyword>apan_phase</keyword>
+      <keyword>apan_phase_oncc\%{N}</keyword>
+      <keyword>apan_waveform</keyword>
+      <keyword>apan_wet</keyword>
+      <keyword>apan_wet_oncc\%{N}</keyword>
       <keyword>bend_down</keyword>
       <keyword>bend_smooth</keyword>
       <keyword>bend_step</keyword>
       <keyword>bend_stepdown</keyword>
       <keyword>bend_stepup</keyword>
       <keyword>bend_up</keyword>
-      <keyword>benddown</keyword>
-      <keyword>bendstep</keyword>
-      <keyword>bendup</keyword>
+      <keyword>bitred</keyword>
+      <keyword>bitred_curvecc\%{N}</keyword>
+      <keyword>bitred_oncc\%{N}</keyword>
+      <keyword>bitred_smoothcc\%{N}</keyword>
+      <keyword>bitred_stepcc\%{N}</keyword>
+      <keyword>bus</keyword>
+      <keyword>bypass_oncc\%{N}</keyword>
+      <keyword>comp_attack</keyword>
+      <keyword>comp_gain</keyword>
+      <keyword>comp_ratio</keyword>
+      <keyword>comp_release</keyword>
+      <keyword>comp_stlink</keyword>
+      <keyword>comp_threshold</keyword>
       <keyword>count</keyword>
       <keyword>curve_index</keyword>
       <keyword>cutoff</keyword>
-      <keyword>cutoff2</keyword>
-      <keyword>cutoff2_curvecc\%{N}</keyword>
-      <keyword>cutoff2_mod</keyword>
-      <keyword>cutoff2_oncc\%{N}</keyword>
-      <keyword>cutoff2_smoothcc\%{N}</keyword>
-      <keyword>cutoff2_stepcc\%{N}</keyword>
       <keyword>cutoff_cc\%{N}</keyword>
       <keyword>cutoff_chanaft</keyword>
       <keyword>cutoff_curvecc\%{N}</keyword>
-      <keyword>cutoff_mod</keyword>
-      <keyword>cutoff_oncc\%{N}</keyword>
       <keyword>cutoff_polyaft</keyword>
       <keyword>cutoff_smoothcc\%{N}</keyword>
       <keyword>cutoff_stepcc\%{N}</keyword>
+      <keyword>decim</keyword>
+      <keyword>decim_curvecc\%{N}</keyword>
+      <keyword>decim_oncc\%{N}</keyword>
+      <keyword>decim_smoothcc\%{N}</keyword>
+      <keyword>decim_stepcc\%{N}</keyword>
       <keyword>default_path</keyword>
       <keyword>delay</keyword>
       <keyword>delay_beats</keyword>
-      <keyword>delay_beats_mod</keyword>
+      <keyword>delay_beats_curvecc\%{N}</keyword>
+      <keyword>delay_beats_oncc\%{N}</keyword>
+      <keyword>delay_beats_random</keyword>
       <keyword>delay_cc\%{N}</keyword>
-      <keyword>delay_mod</keyword>
+      <keyword>delay_curvecc\%{N}</keyword>
+      <keyword>delay_cutoff</keyword>
+      <keyword>delay_cutoff_oncc\%{N}</keyword>
+      <keyword>delay_damphi</keyword>
+      <keyword>delay_damphi_oncc\%{N}</keyword>
+      <keyword>delay_damplo</keyword>
+      <keyword>delay_damplo_oncc\%{N}</keyword>
+      <keyword>delay_dry</keyword>
+      <keyword>delay_dry_oncc\%{N}</keyword>
+      <keyword>delay_feedback</keyword>
+      <keyword>delay_feedback_oncc\%{N}</keyword>
+      <keyword>delay_filter</keyword>
+      <keyword>delay_input</keyword>
+      <keyword>delay_input_oncc\%{N}</keyword>
+      <keyword>delay_levelc</keyword>
+      <keyword>delay_levell</keyword>
+      <keyword>delay_levelr</keyword>
+      <keyword>delay_lfofreq</keyword>
+      <keyword>delay_lfofreq_oncc\%{N}</keyword>
+      <keyword>delay_moddepth</keyword>
+      <keyword>delay_moddepth_oncc\%{N}</keyword>
+      <keyword>delay_mode</keyword>
+      <keyword>delay_panc</keyword>
+      <keyword>delay_panc_oncc\%{N}</keyword>
+      <keyword>delay_panl</keyword>
+      <keyword>delay_panl_oncc\%{N}</keyword>
+      <keyword>delay_panr</keyword>
+      <keyword>delay_panr_oncc\%{N}</keyword>
       <keyword>delay_random</keyword>
+      <keyword>delay_resonance</keyword>
+      <keyword>delay_resonance_oncc\%{N}</keyword>
       <keyword>delay_samples</keyword>
       <keyword>delay_samples_oncc\%{N}</keyword>
+      <keyword>delay_spread</keyword>
+      <keyword>delay_spread_oncc\%{N}</keyword>
+      <keyword>delay_syncc_oncc\%{N}</keyword>
+      <keyword>delay_syncl_oncc\%{N}</keyword>
+      <keyword>delay_syncr_oncc\%{N}</keyword>
+      <keyword>delay_time_tap</keyword>
+      <keyword>delay_timec</keyword>
+      <keyword>delay_timec_oncc\%{N}</keyword>
+      <keyword>delay_timel</keyword>
+      <keyword>delay_timel_oncc\%{N}</keyword>
+      <keyword>delay_timer</keyword>
+      <keyword>delay_timer_oncc\%{N}</keyword>
+      <keyword>delay_wet</keyword>
+      <keyword>delay_wet_oncc\%{N}</keyword>
       <keyword>direction</keyword>
-      <keyword>directives</keyword>
+      <keyword>directtomain</keyword>
+      <keyword>disto_depth</keyword>
+      <keyword>disto_depth_oncc\%{N}</keyword>
+      <keyword>disto_dry</keyword>
+      <keyword>disto_dry_oncc\%{N}</keyword>
+      <keyword>disto_stages</keyword>
+      <keyword>disto_tone</keyword>
+      <keyword>disto_tone_oncc\%{N}</keyword>
+      <keyword>disto_wet</keyword>
+      <keyword>disto_wet_oncc\%{N}</keyword>
+      <keyword>dsp_order</keyword>
       <keyword>effect1</keyword>
       <keyword>effect2</keyword>
-      <keyword>eg\%{N}_amplitude\%{N}</keyword>
-      <keyword>eg\%{N}_amplitude\%{N}_oncc\%{N}</keyword>
+      <keyword>effect3</keyword>
+      <keyword>effect4</keyword>
+      <keyword>eg\%{N}_ampeg</keyword>
+      <keyword>eg\%{N}_amplitude</keyword>
+      <keyword>eg\%{N}_amplitude_oncc\%{N}</keyword>
+      <keyword>eg\%{N}_bitred</keyword>
+      <keyword>eg\%{N}_bitred_oncc\%{N}</keyword>
       <keyword>eg\%{N}_curve\%{N}</keyword>
       <keyword>eg\%{N}_cutoff</keyword>
+      <keyword>eg\%{N}_cutoff_oncc\%{N}</keyword>
       <keyword>eg\%{N}_cutoff2</keyword>
       <keyword>eg\%{N}_cutoff2_oncc\%{N}</keyword>
-      <keyword>eg\%{N}_cutoff_oncc\%{N}</keyword>
+      <keyword>eg\%{N}_decim</keyword>
+      <keyword>eg\%{N}_decim_oncc\%{N}</keyword>
       <keyword>eg\%{N}_depth_lfo\%{N}</keyword>
       <keyword>eg\%{N}_depthadd_lfo\%{N}</keyword>
-      <keyword>eg\%{N}_eq\%{eqN}bw</keyword>
-      <keyword>eg\%{N}_eq\%{eqN}bw_oncc\%{N}</keyword>
-      <keyword>eg\%{N}_eq\%{eqN}freq</keyword>
-      <keyword>eg\%{N}_eq\%{eqN}freq_oncc\%{N}</keyword>
-      <keyword>eg\%{N}_eq\%{eqN}gain</keyword>
-      <keyword>eg\%{N}_eq\%{eqN}gain_oncc\%{N}</keyword>
+      <keyword>eg\%{N}_driveshape</keyword>
+      <keyword>eg\%{N}_driveshape_oncc\%{N}</keyword>
+      <keyword>eg\%{N}_eq\%{N}bw</keyword>
+      <keyword>eg\%{N}_eq\%{N}bw_oncc\%{N}</keyword>
+      <keyword>eg\%{N}_eq\%{N}freq</keyword>
+      <keyword>eg\%{N}_eq\%{N}freq_oncc\%{N}</keyword>
+      <keyword>eg\%{N}_eq\%{N}gain</keyword>
+      <keyword>eg\%{N}_eq\%{N}gain_oncc\%{N}</keyword>
       <keyword>eg\%{N}_freq_lfo\%{N}</keyword>
       <keyword>eg\%{N}_level\%{N}</keyword>
       <keyword>eg\%{N}_level\%{N}_oncc\%{N}</keyword>
       <keyword>eg\%{N}_loop</keyword>
       <keyword>eg\%{N}_loop_count</keyword>
-      <keyword>eg\%{N}_pan\%{N}</keyword>
-      <keyword>eg\%{N}_pan\%{N}_oncc\%{N}</keyword>
+      <keyword>eg\%{N}_noiselevel</keyword>
+      <keyword>eg\%{N}_noiselevel_oncc\%{N}</keyword>
+      <keyword>eg\%{N}_noisestep</keyword>
+      <keyword>eg\%{N}_noisestep_oncc\%{N}</keyword>
+      <keyword>eg\%{N}_noisetone</keyword>
+      <keyword>eg\%{N}_noisetone_oncc\%{N}</keyword>
+      <keyword>eg\%{N}_pan</keyword>
       <keyword>eg\%{N}_pan_curve</keyword>
       <keyword>eg\%{N}_pan_curvecc\%{N}</keyword>
+      <keyword>eg\%{N}_pan_oncc\%{N}</keyword>
       <keyword>eg\%{N}_pitch</keyword>
       <keyword>eg\%{N}_pitch_oncc\%{N}</keyword>
-      <keyword>eg\%{N}_pitch_oncc\%{N}</keyword>
       <keyword>eg\%{N}_points</keyword>
+      <keyword>eg\%{N}_rectify</keyword>
+      <keyword>eg\%{N}_rectify_oncc\%{N}</keyword>
       <keyword>eg\%{N}_resonance</keyword>
+      <keyword>eg\%{N}_resonance_oncc\%{N}</keyword>
       <keyword>eg\%{N}_resonance2</keyword>
       <keyword>eg\%{N}_resonance2_oncc\%{N}</keyword>
-      <keyword>eg\%{N}_resonance_oncc\%{N}</keyword>
-      <keyword>eg\%{N}_shape</keyword>
+      <keyword>eg\%{N}_ringmod</keyword>
+      <keyword>eg\%{N}_ringmod_oncc\%{N}</keyword>
       <keyword>eg\%{N}_shape\%{N}</keyword>
       <keyword>eg\%{N}_sustain</keyword>
       <keyword>eg\%{N}_time\%{N}</keyword>
       <keyword>eg\%{N}_time\%{N}_oncc\%{N}</keyword>
-      <keyword>eg\%{N}_volume\%{N}</keyword>
-      <keyword>eg\%{N}_volume\%{N}_oncc\%{N}</keyword>
-      <keyword>eg\%{N}_width\%{N}</keyword>
-      <keyword>eg\%{N}_width\%{N}_oncc\%{N}</keyword>
+      <keyword>eg\%{N}_volume</keyword>
+      <keyword>eg\%{N}_volume_oncc\%{N}</keyword>
+      <keyword>eg\%{N}_width</keyword>
+      <keyword>eg\%{N}_width_oncc\%{N}</keyword>
       <keyword>end</keyword>
-      <keyword>eq\%{eqN}_bw</keyword>
-      <keyword>eq\%{eqN}_bwcc\%{N}</keyword>
-      <keyword>eq\%{eqN}_bw_oncc\%{N}</keyword>
-      <keyword>eq\%{eqN}_dynamic</keyword>
-      <keyword>eq\%{eqN}_freq</keyword>
-      <keyword>eq\%{eqN}_freqcc\%{N}</keyword>
-      <keyword>eq\%{eqN}_freq_oncc\%{N}</keyword>
-      <keyword>eq\%{eqN}_gain</keyword>
-      <keyword>eq\%{eqN}_gaincc\%{N}</keyword>
-      <keyword>eq\%{eqN}_gain_oncc\%{N}</keyword>
-      <keyword>eq\%{eqN}_type</keyword>
-      <keyword>eq\%{eqN}_vel2freq</keyword>
-      <keyword>eq\%{eqN}_vel2gain</keyword>
-      <keyword>fil2_gain</keyword>
-      <keyword>fil2_type</keyword>
+      <keyword>eq_bw</keyword>
+      <keyword>eq_bw_oncc\%{N}</keyword>
+      <keyword>eq_freq</keyword>
+      <keyword>eq_freq_oncc\%{N}</keyword>
+      <keyword>eq_gain</keyword>
+      <keyword>eq_gain_oncc\%{N}</keyword>
+      <keyword>eq_type</keyword>
+      <keyword>eq\%{N}_bw</keyword>
+      <keyword>eq\%{N}_bwcc\%{N}</keyword>
+      <keyword>eq\%{N}_dynamic</keyword>
+      <keyword>eq\%{N}_freq</keyword>
+      <keyword>eq\%{N}_freqcc\%{N}</keyword>
+      <keyword>eq\%{N}_gain</keyword>
+      <keyword>eq\%{N}_gaincc\%{N}</keyword>
+      <keyword>eq\%{N}_type</keyword>
+      <keyword>eq\%{N}_vel2freq</keyword>
+      <keyword>eq\%{N}_vel2gain</keyword>
       <keyword>fil_gain</keyword>
+      <keyword>fil_gain_oncc\%{N}</keyword>
       <keyword>fil_keycenter</keyword>
       <keyword>fil_keytrack</keyword>
       <keyword>fil_random</keyword>
@@ -240,19 +322,26 @@
       <keyword>fil_veltrack</keyword>
       <keyword>fileg_attack</keyword>
       <keyword>fileg_attack_oncc\%{N}</keyword>
-      <keyword>fileg_attackcc\%{N}</keyword>
+      <keyword>fileg_attack_shape</keyword>
       <keyword>fileg_decay</keyword>
       <keyword>fileg_decay_oncc\%{N}</keyword>
-      <keyword>fileg_decaycc\%{N}</keyword>
+      <keyword>fileg_decay_shape</keyword>
+      <keyword>fileg_decay_zero</keyword>
       <keyword>fileg_delay</keyword>
+      <keyword>fileg_delay_oncc\%{N}</keyword>
       <keyword>fileg_depth</keyword>
       <keyword>fileg_depth_oncc\%{N}</keyword>
-      <keyword>fileg_depthcc\%{N}</keyword>
       <keyword>fileg_dynamic</keyword>
       <keyword>fileg_hold</keyword>
+      <keyword>fileg_hold_oncc\%{N}</keyword>
       <keyword>fileg_release</keyword>
+      <keyword>fileg_release_oncc\%{N}</keyword>
+      <keyword>fileg_release_shape</keyword>
+      <keyword>fileg_release_zero</keyword>
       <keyword>fileg_start</keyword>
+      <keyword>fileg_start_oncc\%{N}</keyword>
       <keyword>fileg_sustain</keyword>
+      <keyword>fileg_sustain_oncc\%{N}</keyword>
       <keyword>fileg_vel2attack</keyword>
       <keyword>fileg_vel2decay</keyword>
       <keyword>fileg_vel2delay</keyword>
@@ -270,13 +359,27 @@
       <keyword>fillfo_freqcc\%{N}</keyword>
       <keyword>fillfo_freqchanaft</keyword>
       <keyword>fillfo_freqpolyaft</keyword>
-      <keyword>filtype</keyword>
+      <keyword>filter_cutoff</keyword>
+      <keyword>filter_cutoff_oncc\%{N}</keyword>
+      <keyword>filter_resonance</keyword>
+      <keyword>filter_resonance_oncc\%{N}</keyword>
+      <keyword>filter_type</keyword>
+      <keyword>fx\%{N}tomain</keyword>
+      <keyword>fx\%{N}tomix</keyword>
       <keyword>gain_cc\%{N}</keyword>
-      <keyword>gain_oncc\%{N}</keyword>
+      <keyword>gate_attack</keyword>
+      <keyword>gate_oncc\%{N}</keyword>
+      <keyword>gate_release</keyword>
+      <keyword>gate_stlink</keyword>
+      <keyword>gate_threshold</keyword>
       <keyword>global_amplitude</keyword>
+      <keyword>global_label</keyword>
+      <keyword>global_tune</keyword>
       <keyword>global_volume</keyword>
       <keyword>group</keyword>
       <keyword>group_amplitude</keyword>
+      <keyword>group_label</keyword>
+      <keyword>group_tune</keyword>
       <keyword>group_volume</keyword>
       <keyword>hibend</keyword>
       <keyword>hibpm</keyword>
@@ -285,43 +388,54 @@
       <keyword>hichanaft</keyword>
       <keyword>hihdcc\%{N}</keyword>
       <keyword>hikey</keyword>
-      <keyword>hint_([a-z]*)</keyword>
+      <keyword>hint_*</keyword>
       <keyword>hipolyaft</keyword>
       <keyword>hiprog</keyword>
       <keyword>hirand</keyword>
       <keyword>hitimer</keyword>
       <keyword>hivel</keyword>
+      <keyword>image</keyword>
+      <keyword>internal</keyword>
       <keyword>key</keyword>
       <keyword>label_cc\%{N}</keyword>
+      <keyword>label_key\%{N}</keyword>
       <keyword>lfo\%{N}_amplitude</keyword>
       <keyword>lfo\%{N}_amplitude_oncc\%{N}</keyword>
       <keyword>lfo\%{N}_amplitude_smoothcc\%{N}</keyword>
       <keyword>lfo\%{N}_amplitude_stepcc\%{N}</keyword>
+      <keyword>lfo\%{N}_bitred</keyword>
+      <keyword>lfo\%{N}_bitred_oncc\%{N}</keyword>
+      <keyword>lfo\%{N}_bitred_smoothcc\%{N}</keyword>
+      <keyword>lfo\%{N}_bitred_stepcc\%{N}</keyword>
       <keyword>lfo\%{N}_count</keyword>
       <keyword>lfo\%{N}_cutoff</keyword>
-      <keyword>lfo\%{N}_cutoff2</keyword>
-      <keyword>lfo\%{N}_cutoff2_oncc\%{N}</keyword>
-      <keyword>lfo\%{N}_cutoff2_smoothcc\%{N}</keyword>
-      <keyword>lfo\%{N}_cutoff2_stepcc\%{N}</keyword>
       <keyword>lfo\%{N}_cutoff_oncc\%{N}</keyword>
       <keyword>lfo\%{N}_cutoff_smoothcc\%{N}</keyword>
       <keyword>lfo\%{N}_cutoff_stepcc\%{N}</keyword>
+      <keyword>lfo\%{N}_decim</keyword>
+      <keyword>lfo\%{N}_decim_oncc\%{N}</keyword>
+      <keyword>lfo\%{N}_decim_smoothcc\%{N}</keyword>
+      <keyword>lfo\%{N}_decim_stepcc\%{N}</keyword>
       <keyword>lfo\%{N}_delay</keyword>
       <keyword>lfo\%{N}_delay_oncc\%{N}</keyword>
       <keyword>lfo\%{N}_depth_lfo\%{N}</keyword>
       <keyword>lfo\%{N}_depthadd_lfo\%{N}</keyword>
-      <keyword>lfo\%{N}_eq\%{eqN}bw</keyword>
-      <keyword>lfo\%{N}_eq\%{eqN}bw_oncc\%{N}</keyword>
-      <keyword>lfo\%{N}_eq\%{eqN}bw_smoothcc\%{N}</keyword>
-      <keyword>lfo\%{N}_eq\%{eqN}bw_stepcc\%{N}</keyword>
-      <keyword>lfo\%{N}_eq\%{eqN}freq</keyword>
-      <keyword>lfo\%{N}_eq\%{eqN}freq_oncc\%{N}</keyword>
-      <keyword>lfo\%{N}_eq\%{eqN}freq_smoothcc\%{N}</keyword>
-      <keyword>lfo\%{N}_eq\%{eqN}freq_stepcc\%{N}</keyword>
-      <keyword>lfo\%{N}_eq\%{eqN}gain</keyword>
-      <keyword>lfo\%{N}_eq\%{eqN}gain_oncc\%{N}</keyword>
-      <keyword>lfo\%{N}_eq\%{eqN}gain_smoothcc\%{N}</keyword>
-      <keyword>lfo\%{N}_eq\%{eqN}gain_stepcc\%{N}</keyword>
+      <keyword>lfo\%{N}_drive</keyword>
+      <keyword>lfo\%{N}_drive_oncc\%{N}</keyword>
+      <keyword>lfo\%{N}_drive_smoothcc\%{N}</keyword>
+      <keyword>lfo\%{N}_drive_stepcc\%{N}</keyword>
+      <keyword>lfo\%{N}_eq\%{N}bw</keyword>
+      <keyword>lfo\%{N}_eq\%{N}bw_oncc\%{N}</keyword>
+      <keyword>lfo\%{N}_eq\%{N}bw_smoothcc\%{N}</keyword>
+      <keyword>lfo\%{N}_eq\%{N}bw_stepcc\%{N}</keyword>
+      <keyword>lfo\%{N}_eq\%{N}freq</keyword>
+      <keyword>lfo\%{N}_eq\%{N}freq_oncc\%{N}</keyword>
+      <keyword>lfo\%{N}_eq\%{N}freq_smoothcc\%{N}</keyword>
+      <keyword>lfo\%{N}_eq\%{N}freq_stepcc\%{N}</keyword>
+      <keyword>lfo\%{N}_eq\%{N}gain</keyword>
+      <keyword>lfo\%{N}_eq\%{N}gain_oncc\%{N}</keyword>
+      <keyword>lfo\%{N}_eq\%{N}gain_smoothcc\%{N}</keyword>
+      <keyword>lfo\%{N}_eq\%{N}gain_stepcc\%{N}</keyword>
       <keyword>lfo\%{N}_fade</keyword>
       <keyword>lfo\%{N}_fade_oncc\%{N}</keyword>
       <keyword>lfo\%{N}_freq</keyword>
@@ -330,8 +444,19 @@
       <keyword>lfo\%{N}_freq_oncc\%{N}</keyword>
       <keyword>lfo\%{N}_freq_smoothcc\%{N}</keyword>
       <keyword>lfo\%{N}_freq_stepcc\%{N}</keyword>
+      <keyword>lfo\%{N}_noiselevel</keyword>
+      <keyword>lfo\%{N}_noiselevel_oncc\%{N}</keyword>
+      <keyword>lfo\%{N}_noiselevel_smoothcc\%{N}</keyword>
+      <keyword>lfo\%{N}_noiselevel_stepcc\%{N}</keyword>
+      <keyword>lfo\%{N}_noisestep</keyword>
+      <keyword>lfo\%{N}_noisestep_oncc\%{N}</keyword>
+      <keyword>lfo\%{N}_noisestep_smoothcc\%{N}</keyword>
+      <keyword>lfo\%{N}_noisestep_stepcc\%{N}</keyword>
+      <keyword>lfo\%{N}_noisetone</keyword>
+      <keyword>lfo\%{N}_noisetone_oncc\%{N}</keyword>
+      <keyword>lfo\%{N}_noisetone_smoothcc\%{N}</keyword>
+      <keyword>lfo\%{N}_noisetone_stepcc\%{N}</keyword>
       <keyword>lfo\%{N}_offset</keyword>
-      <keyword>lfo\%{N}_offset([2-8]{1})</keyword>
       <keyword>lfo\%{N}_pan</keyword>
       <keyword>lfo\%{N}_pan_oncc\%{N}</keyword>
       <keyword>lfo\%{N}_pan_smoothcc\%{N}</keyword>
@@ -339,36 +464,34 @@
       <keyword>lfo\%{N}_phase</keyword>
       <keyword>lfo\%{N}_phase_oncc\%{N}</keyword>
       <keyword>lfo\%{N}_pitch</keyword>
+      <keyword>lfo\%{N}_pitch_curvecc\%{N}</keyword>
       <keyword>lfo\%{N}_pitch_oncc\%{N}</keyword>
       <keyword>lfo\%{N}_pitch_smoothcc\%{N}</keyword>
       <keyword>lfo\%{N}_pitch_stepcc\%{N}</keyword>
       <keyword>lfo\%{N}_ratio</keyword>
-      <keyword>lfo\%{N}_ratio([2-8]{1})</keyword>
       <keyword>lfo\%{N}_resonance</keyword>
-      <keyword>lfo\%{N}_resonance2</keyword>
-      <keyword>lfo\%{N}_resonance2_oncc\%{N}</keyword>
-      <keyword>lfo\%{N}_resonance2_smoothcc\%{N}</keyword>
-      <keyword>lfo\%{N}_resonance2_stepcc\%{N}</keyword>
       <keyword>lfo\%{N}_resonance_oncc\%{N}</keyword>
       <keyword>lfo\%{N}_resonance_smoothcc\%{N}</keyword>
       <keyword>lfo\%{N}_resonance_stepcc\%{N}</keyword>
       <keyword>lfo\%{N}_scale</keyword>
-      <keyword>lfo\%{N}_scale([2-8]{1})</keyword>
       <keyword>lfo\%{N}_smooth</keyword>
       <keyword>lfo\%{N}_smooth_oncc\%{N}</keyword>
       <keyword>lfo\%{N}_step\%{N}</keyword>
+      <keyword>lfo\%{N}_step\%{N}_oncc\%{N}</keyword>
       <keyword>lfo\%{N}_steps</keyword>
       <keyword>lfo\%{N}_volume</keyword>
       <keyword>lfo\%{N}_volume_oncc\%{N}</keyword>
       <keyword>lfo\%{N}_volume_smoothcc\%{N}</keyword>
       <keyword>lfo\%{N}_volume_stepcc\%{N}</keyword>
       <keyword>lfo\%{N}_wave</keyword>
-      <keyword>lfo\%{N}_wave([2-8]{1})</keyword>
       <keyword>lfo\%{N}_wave_oncc\%{N}</keyword>
       <keyword>lfo\%{N}_width</keyword>
       <keyword>lfo\%{N}_width_oncc\%{N}</keyword>
       <keyword>lfo\%{N}_width_smoothcc\%{N}</keyword>
       <keyword>lfo\%{N}_width_stepcc\%{N}</keyword>
+      <keyword>load_end</keyword>
+      <keyword>load_mode</keyword>
+      <keyword>load_start</keyword>
       <keyword>lobend</keyword>
       <keyword>lobpm</keyword>
       <keyword>locc\%{N}</keyword>
@@ -379,20 +502,31 @@
       <keyword>loop_count</keyword>
       <keyword>loop_crossfade</keyword>
       <keyword>loop_end</keyword>
+      <keyword>loop_lengthcc\%{N}</keyword>
       <keyword>loop_mode</keyword>
       <keyword>loop_start</keyword>
+      <keyword>loop_startcc\%{N}</keyword>
+      <keyword>loop_tune</keyword>
       <keyword>loop_type</keyword>
-      <keyword>loopend</keyword>
-      <keyword>loopmode</keyword>
-      <keyword>loopstart</keyword>
       <keyword>lopolyaft</keyword>
       <keyword>loprog</keyword>
       <keyword>lorand</keyword>
       <keyword>lotimer</keyword>
       <keyword>lovel</keyword>
       <keyword>master_amplitude</keyword>
+      <keyword>master_label</keyword>
+      <keyword>master_tune</keyword>
       <keyword>master_volume</keyword>
       <keyword>md5</keyword>
+      <keyword>noise_filter</keyword>
+      <keyword>noise_level</keyword>
+      <keyword>noise_level_oncc\%{N}</keyword>
+      <keyword>noise_level_smoothcc\%{N}</keyword>
+      <keyword>noise_step</keyword>
+      <keyword>noise_step_oncc\%{N}</keyword>
+      <keyword>noise_stereo</keyword>
+      <keyword>noise_tone</keyword>
+      <keyword>noise_tone_oncc\%{N}</keyword>
       <keyword>note_offset</keyword>
       <keyword>note_polyphony</keyword>
       <keyword>note_selfmask</keyword>
@@ -404,53 +538,85 @@
       <keyword>off_time</keyword>
       <keyword>offset</keyword>
       <keyword>offset_cc\%{N}</keyword>
-      <keyword>offset_mod</keyword>
       <keyword>offset_random</keyword>
       <keyword>on_hicc\%{N}</keyword>
+      <keyword>on_hihdcc\%{N}</keyword>
       <keyword>on_locc\%{N}</keyword>
+      <keyword>on_lohdcc\%{N}</keyword>
+      <keyword>oscillator</keyword>
+      <keyword>oscillator_detune</keyword>
+      <keyword>oscillator_detune_oncc\%{N}</keyword>
+      <keyword>oscillator_mod_depth</keyword>
+      <keyword>oscillator_mod_depth_oncc\%{N}</keyword>
+      <keyword>oscillator_mod_smoothcc\%{N}</keyword>
+      <keyword>oscillator_mode</keyword>
+      <keyword>oscillator_multi</keyword>
+      <keyword>oscillator_phase</keyword>
+      <keyword>oscillator_quality</keyword>
+      <keyword>oscillator_table_size</keyword>
       <keyword>output</keyword>
       <keyword>pan</keyword>
-      <keyword>pan_oncc\%{N}</keyword>
-      <keyword>pan_cc\%{N}</keyword>
       <keyword>pan_curvecc\%{N}</keyword>
+      <keyword>pan_keycenter</keyword>
+      <keyword>pan_keytrack</keyword>
       <keyword>pan_law</keyword>
-      <keyword>pan_mod</keyword>
       <keyword>pan_oncc\%{N}</keyword>
+      <keyword>pan_random</keyword>
       <keyword>pan_smoothcc\%{N}</keyword>
       <keyword>pan_stepcc\%{N}</keyword>
+      <keyword>pan_veltrack</keyword>
       <keyword>param_offset</keyword>
       <keyword>phase</keyword>
+      <keyword>phaser_depth</keyword>
+      <keyword>phaser_depth_oncc\%{N}</keyword>
+      <keyword>phaser_feedback</keyword>
+      <keyword>phaser_feedback_oncc\%{N}</keyword>
+      <keyword>phaser_freq</keyword>
+      <keyword>phaser_freq_oncc\%{N}</keyword>
+      <keyword>phaser_phase_oncc\%{N}</keyword>
+      <keyword>phaser_stages</keyword>
+      <keyword>phaser_waveform</keyword>
+      <keyword>phaser_wet</keyword>
+      <keyword>phaser_wet_oncc\%{N}</keyword>
       <keyword>pitch_curvecc\%{N}</keyword>
       <keyword>pitch_keycenter</keyword>
       <keyword>pitch_keytrack</keyword>
-      <keyword>pitch_mod</keyword>
       <keyword>pitch_oncc\%{N}</keyword>
       <keyword>pitch_random</keyword>
       <keyword>pitch_smoothcc\%{N}</keyword>
       <keyword>pitch_stepcc\%{N}</keyword>
       <keyword>pitch_veltrack</keyword>
       <keyword>pitcheg_attack</keyword>
+      <keyword>pitcheg_attack_oncc\%{N}</keyword>
+      <keyword>pitcheg_attack_shape</keyword>
       <keyword>pitcheg_decay</keyword>
       <keyword>pitcheg_decay_oncc\%{N}</keyword>
       <keyword>pitcheg_decay_shape</keyword>
+      <keyword>pitcheg_decay_zero</keyword>
       <keyword>pitcheg_delay</keyword>
       <keyword>pitcheg_delay_oncc\%{N}</keyword>
       <keyword>pitcheg_depth</keyword>
       <keyword>pitcheg_depth_oncc\%{N}</keyword>
       <keyword>pitcheg_dynamic</keyword>
       <keyword>pitcheg_hold</keyword>
+      <keyword>pitcheg_hold_oncc\%{N}</keyword>
       <keyword>pitcheg_release</keyword>
+      <keyword>pitcheg_release_oncc\%{N}</keyword>
+      <keyword>pitcheg_release_shape</keyword>
+      <keyword>pitcheg_release_zero</keyword>
       <keyword>pitcheg_start</keyword>
+      <keyword>pitcheg_start_oncc\%{N}</keyword>
       <keyword>pitcheg_sustain</keyword>
+      <keyword>pitcheg_sustain_oncc\%{N}</keyword>
       <keyword>pitcheg_vel2attack</keyword>
       <keyword>pitcheg_vel2decay</keyword>
       <keyword>pitcheg_vel2delay</keyword>
       <keyword>pitcheg_vel2depth</keyword>
       <keyword>pitcheg_vel2hold</keyword>
       <keyword>pitcheg_vel2release</keyword>
+      <keyword>pitcheg_vel2sustain</keyword>
       <keyword>pitchlfo_delay</keyword>
       <keyword>pitchlfo_depth</keyword>
-      <keyword>pitchlfo_depth_oncc\%{N}</keyword>
       <keyword>pitchlfo_depthcc\%{N}</keyword>
       <keyword>pitchlfo_depthchanaft</keyword>
       <keyword>pitchlfo_depthpolyaft</keyword>
@@ -460,42 +626,71 @@
       <keyword>pitchlfo_freqchanaft</keyword>
       <keyword>pitchlfo_freqpolyaft</keyword>
       <keyword>polyphony</keyword>
-      <keyword>polyphony_group</keyword>
+      <keyword>polyphony_stealing</keyword>
       <keyword>position</keyword>
-      <keyword>position_mod</keyword>
+      <keyword>position_curvecc\%{N}</keyword>
+      <keyword>position_keycenter</keyword>
+      <keyword>position_keytrack</keyword>
+      <keyword>position_oncc\%{N}</keyword>
+      <keyword>position_random</keyword>
+      <keyword>position_smoothcc\%{N}</keyword>
+      <keyword>position_stepcc\%{N}</keyword>
+      <keyword>position_veltrack</keyword>
+      <keyword>region_label</keyword>
       <keyword>resonance</keyword>
-      <keyword>resonance2</keyword>
-      <keyword>resonance2_cc\%{N}</keyword>
-      <keyword>resonance2_curvecc\%{N}</keyword>
-      <keyword>resonance2_mod</keyword>
-      <keyword>resonance2_oncc\%{N}</keyword>
-      <keyword>resonance2_smoothcc\%{N}</keyword>
-      <keyword>resonance2_stepcc\%{N}</keyword>
-      <keyword>resonance_cc\%{N}</keyword>
       <keyword>resonance_curvecc\%{N}</keyword>
-      <keyword>resonance_mod</keyword>
       <keyword>resonance_oncc\%{N}</keyword>
+      <keyword>resonance_random</keyword>
       <keyword>resonance_smoothcc\%{N}</keyword>
       <keyword>resonance_stepcc\%{N}</keyword>
+      <keyword>reverb_damp</keyword>
+      <keyword>reverb_damp_oncc\%{N}</keyword>
+      <keyword>reverb_dry</keyword>
+      <keyword>reverb_dry_oncc\%{N}</keyword>
+      <keyword>reverb_input</keyword>
+      <keyword>reverb_input_oncc\%{N}</keyword>
+      <keyword>reverb_predelay</keyword>
+      <keyword>reverb_predelay_oncc\%{N}</keyword>
+      <keyword>reverb_size</keyword>
+      <keyword>reverb_size_oncc\%{N}</keyword>
+      <keyword>reverb_tone</keyword>
+      <keyword>reverb_tone_oncc\%{N}</keyword>
+      <keyword>reverb_type</keyword>
+      <keyword>reverb_wet</keyword>
+      <keyword>reverb_wet_oncc\%{N}</keyword>
       <keyword>reverse_hicc\%{N}</keyword>
       <keyword>reverse_locc\%{N}</keyword>
       <keyword>rt_dead</keyword>
       <keyword>rt_decay</keyword>
       <keyword>sample</keyword>
+      <keyword>sample_fadeout</keyword>
+      <keyword>sample_quality</keyword>
+      <keyword>script</keyword>
       <keyword>seq_length</keyword>
       <keyword>seq_position</keyword>
       <keyword>set_cc\%{N}</keyword>
       <keyword>set_hdcc\%{N}</keyword>
-      <keyword>sostenuto_cc\%{N}</keyword>
+      <keyword>sostenuto_cc</keyword>
       <keyword>sostenuto_lo</keyword>
       <keyword>sostenuto_sw</keyword>
-      <keyword>start_hicc\%{N}</keyword>
-      <keyword>start_locc\%{N}</keyword>
+      <keyword>static_cyclic_level</keyword>
+      <keyword>static_cyclic_time</keyword>
+      <keyword>static_filter</keyword>
+      <keyword>static_level</keyword>
+      <keyword>static_level_oncc\%{N}</keyword>
+      <keyword>static_random_level</keyword>
+      <keyword>static_random_maxtime</keyword>
+      <keyword>static_random_mintime</keyword>
+      <keyword>static_stereo</keyword>
+      <keyword>static_tone</keyword>
       <keyword>stop_beats</keyword>
-      <keyword>stop_beats_mod</keyword>
       <keyword>stop_hicc\%{N}</keyword>
+      <keyword>stop_hihdcc\%{N}</keyword>
       <keyword>stop_locc\%{N}</keyword>
-      <keyword>sustain_cc\%{N}</keyword>
+      <keyword>stop_lohdcc\%{N}</keyword>
+      <keyword>strings_number</keyword>
+      <keyword>strings_wet_oncc\%{N}</keyword>
+      <keyword>sustain_cc</keyword>
       <keyword>sustain_lo</keyword>
       <keyword>sustain_sw</keyword>
       <keyword>sw_default</keyword>
@@ -513,40 +708,32 @@
       <keyword>sw_vel</keyword>
       <keyword>sync_beats</keyword>
       <keyword>sync_offset</keyword>
+      <keyword>tdfir_dry</keyword>
+      <keyword>tdfir_dry_oncc\%{N}</keyword>
+      <keyword>tdfir_gain</keyword>
+      <keyword>tdfir_impulse</keyword>
+      <keyword>tdfir_wet</keyword>
+      <keyword>tdfir_wet_oncc\%{N}</keyword>
       <keyword>transpose</keyword>
       <keyword>trigger</keyword>
       <keyword>tune</keyword>
-      <keyword>tune_cc\%{N}</keyword>
-      <keyword>tune_mod</keyword>
-      <keyword>tune_oncc\%{N}</keyword>
       <keyword>type</keyword>
       <keyword>v\%{N}</keyword>
-      <keyword>var\%{N}_amplitude</keyword>
+      <keyword>var\%{N}_*</keyword>
       <keyword>var\%{N}_curvecc\%{N}</keyword>
-      <keyword>var\%{N}_cutoff</keyword>
-      <keyword>var\%{N}_cutoff2</keyword>
-      <keyword>var\%{N}_eq\%{eqN}bw</keyword>
-      <keyword>var\%{N}_eq\%{eqN}freq</keyword>
-      <keyword>var\%{N}_eq\%{eqN}gain</keyword>
       <keyword>var\%{N}_mod</keyword>
       <keyword>var\%{N}_oncc\%{N}</keyword>
-      <keyword>var\%{N}_pan</keyword>
-      <keyword>var\%{N}_pitch</keyword>
-      <keyword>var\%{N}_resonance</keyword>
-      <keyword>var\%{N}_resonance2</keyword>
-      <keyword>var\%{N}_volume</keyword>
-      <keyword>var\%{N}_width</keyword>
       <keyword>vendor_specific</keyword>
       <keyword>volume</keyword>
       <keyword>volume_curvecc\%{N}</keyword>
-      <keyword>volume_mod</keyword>
-      <keyword>volume_oncc\%{N}</keyword>
       <keyword>volume_smoothcc\%{N}</keyword>
       <keyword>volume_stepcc\%{N}</keyword>
       <keyword>waveguide</keyword>
       <keyword>width</keyword>
-      <keyword>width_mod</keyword>
+      <keyword>width_curvecc\%{N}</keyword>
       <keyword>width_oncc\%{N}</keyword>
+      <keyword>width_smoothcc\%{N}</keyword>
+      <keyword>width_stepcc\%{N}</keyword>
       <keyword>xf_cccurve</keyword>
       <keyword>xf_keycurve</keyword>
       <keyword>xf_velcurve</keyword>
@@ -563,7 +750,6 @@
       <keyword>xfout_lokey</keyword>
       <keyword>xfout_lovel</keyword>
     </context>
-
     <context id="preprocessors" style-ref="preprocessor">
       <match extended="true">
         \%{preproc-start}
@@ -574,8 +760,6 @@
         <context id="included-file" sub-pattern="2" style-ref="included-file" class="path"/>
       </include>
     </context>
-
-    <!--Main context-->
     <context id="sfz" class="no-spell-check">
       <include>
         <context ref="gtk-doc:inline-docs-section"/>
@@ -590,5 +774,7 @@
         <context ref="decimal"/>
       </include>
     </context>
+    <!-- http://www.lysator.liu.se/c/ANSI-C-grammar-l.html -->
+    <!--Main context-->
   </definitions>
 </language>


### PR DESCRIPTION
I have written a script which auto generates the sfz.lang file based on the sfzformat syntax.yml file
https://github.com/kmturley/sfz-syntax-highlighters

This is the result. I have tested a little on Mac and appears to be functioning correctly. I might have missed some variables if you can double-check all is correct?

<img width="894" alt="Screenshot 2023-02-16 at 10 03 21 PM" src="https://user-images.githubusercontent.com/1710493/219562398-75c7e28a-69e6-4ed9-86bb-f8d758ffb166.png">
